### PR TITLE
fix: correct Tauri broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ git clone https://github.com/maximegris/angular-tauri.git
 
 *Install Tauri (Rust)*
 
-https://tauri.studio/docs/getting-started/prerequisites
+https://v2.tauri.app/start/prerequisites
 
 *Install dependencies with npm:*
 


### PR DESCRIPTION
# Description

Fix broken link to Tauri website in README.

The current link redirects to an unrelated website instead of the official Tauri documentation.

## Changes
- Updated the Tauri website URL to point to the correct official documentation
- Ensures users can access the proper Tauri resources referenced in the README

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


